### PR TITLE
Change to comment in plugin-loader.php

### DIFF
--- a/client-mu-plugins/plugin-loader.php
+++ b/client-mu-plugins/plugin-loader.php
@@ -12,4 +12,4 @@
 
 // wpcom_vip_load_plugin( 'plugin-name' );
 // Note the above requires a specific naming structure: /plugin-name/plugin-name.php
-// You can also specify a specific root file: wpcom_vip_load_plugin( '/plugin-name/plugin.php' );
+// You can also specify a specific root file: wpcom_vip_load_plugin( 'plugin-name/plugin.php' );


### PR DESCRIPTION
Apologies if this PR is not in line with your internal workflow, just wanted to point out that using a leading slash as the comment suggests would cause an error: 

> wpcom_vip_load_plugin() was called with multiple subdirectories