### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,11 @@ mu-plugins
 # drop-ins; these are managed at the platform-level
 object-cache.php
 db.php
+
+# Ignore temporary OS files
+.DS_Store
+.DS_Store?
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
Prevent `.DS_Store` files from being accidentally committed by devs who don't have it in their global `.gitignore`.