### PR TITLE
Add a warning to inform users that WP core API/functions are not available.

### DIFF
--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Hi there, VIP dev!
  *
@@ -7,8 +6,12 @@
  * and such, we've taken care of that for you. This is just for if you need to define an API key or something
  * of that nature.
  *
+ * WARNING: this file is loaded very early,
+ * and most WordPress APIs are not available, hence the code should be limited to pure PHP.
+ *
+ * @see https://vip.wordpress.com/documentation/vip-go/understanding-your-vip-go-codebase/
+ *
  * Happy Coding!
  *
  * - The WordPress.com VIP Team
  **/
- 

--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -6,8 +6,8 @@
  * and such, we've taken care of that for you. This is just for if you need to define an API key or something
  * of that nature.
  *
- * WARNING: this file is loaded very early,
- * and most WordPress APIs are not available, hence the code should be limited to pure PHP.
+ * WARNING: This file is loaded very early (immediately after `wp-config.php`), which means that most WordPress APIs,
+ *   classes, and functions are not available. The code below should be limited to pure PHP.
  *
  * @see https://vip.wordpress.com/documentation/vip-go/understanding-your-vip-go-codebase/
  *


### PR DESCRIPTION
Occasionally, people put `add_filter` and the likes in `vip-config.php` and fatal their sites. 

This PR adds a friendly reminder that WP core API/functions are not available in vip-config.php.
