### PR TITLE
Only ignore db/object-cache files at root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@ uploads
 mu-plugins
 
 # drop-ins; these are managed at the platform-level
-object-cache.php
-db.php
+/object-cache.php
+/db.php
 
 # Ignore temporary OS files
 .DS_Store


### PR DESCRIPTION
Okay to have files in subdirectories with those names (which some plugins do).

Props @hanifn 