### PR TITLE
Limit the maximum number of revisions

### DIFF
--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -15,3 +15,10 @@
  *
  * - The WordPress.com VIP Team
  **/
+
+// Set a high default limit to avoid too many revisions from polluting the database.
+// Posts with extremely high revisions can result in fatal errors or have performance issues.
+// Feel free to adjust this depending on your use cases.
+if ( ! defined( 'WP_POST_REVISIONS' ) ) {
+	define( 'WP_POST_REVISIONS', 500 );
+}


### PR DESCRIPTION
Sets the maximum post revisions stored in the database to 500 on all new VIP Go environments. This limit can be changed or lifted by any client with write access to the repo.

First discussed on BB8. Addresses vip-issues (#551 and #426).