### PR TITLE
Enable VIP_JETPACK_IS_PRIVATE in dev environments

### DIFF
--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -22,3 +22,12 @@
 if ( ! defined( 'WP_POST_REVISIONS' ) ) {
 	define( 'WP_POST_REVISIONS', 500 );
 }
+
+// The VIP_JETPACK_IS_PRIVATE constant is enabled by default in non-production environments.
+// It disables programmatic access to content via the WordPress.com REST API and Jetpack Search;
+// subscriptions via the WordPress.com Reader; and syndication via the WordPress.com Firehose.
+// More information about these features is available in our documentation:
+// https://wpvip.com/documentation/vip-go/restricting-access-to-a-site-hosted-on-vip-go/#controlling-content-distribution-via-jetpack
+if ( ! defined( 'VIP_JETPACK_IS_PRIVATE' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) {
+    define( 'VIP_JETPACK_IS_PRIVATE', true );
+}

--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -16,18 +16,29 @@
  * - The WordPress.com VIP Team
  **/
 
-// Set a high default limit to avoid too many revisions from polluting the database.
-// Posts with extremely high revisions can result in fatal errors or have performance issues.
-// Feel free to adjust this depending on your use cases.
+/**
+ * Set a high default limit to avoid too many revisions from polluting the database.
+ *
+ * Posts with extremely high revisions can result in fatal errors or have performance issues.
+ *
+ * Feel free to adjust this depending on your use cases.
+ */
 if ( ! defined( 'WP_POST_REVISIONS' ) ) {
 	define( 'WP_POST_REVISIONS', 500 );
 }
 
-// The VIP_JETPACK_IS_PRIVATE constant is enabled by default in non-production environments.
-// It disables programmatic access to content via the WordPress.com REST API and Jetpack Search;
-// subscriptions via the WordPress.com Reader; and syndication via the WordPress.com Firehose.
-// More information about these features is available in our documentation:
-// https://wpvip.com/documentation/vip-go/restricting-access-to-a-site-hosted-on-vip-go/#controlling-content-distribution-via-jetpack
-if ( ! defined( 'VIP_JETPACK_IS_PRIVATE' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) {
+/**
+ * The VIP_JETPACK_IS_PRIVATE constant is enabled by default in non-production environments.
+ * 
+ * It disables programmatic access to content via the WordPress.com REST API and Jetpack Search;
+ * subscriptions via the WordPress.com Reader; and syndication via the WordPress.com Firehose.
+ *
+ * You can disable "private" mode (e.g. for testing) in non-production environment by setting the constant to `true` below (or just by removing the lines).
+ * 
+ * @see https://wpvip.com/documentation/vip-go/restricting-access-to-a-site-hosted-on-vip-go/#controlling-content-distribution-via-jetpack
+ */
+if ( ! defined( 'VIP_JETPACK_IS_PRIVATE' ) &&
+    defined( 'VIP_GO_APP_ENVIRONMENT' ) &&
+    'production' !== VIP_GO_APP_ENVIRONMENT ) ) {
     define( 'VIP_JETPACK_IS_PRIVATE', true );
 }


### PR DESCRIPTION
Defines the VIP_JETPACK_IS_PRIVATE constant by default in non-production environments. Updates to client-facing documentation will be needed to clarify this is now the default. Further discussion on P2: https://wp.me/p6jPRI-3eT