### PR TITLE
Disable New Relic Browser instrumentation

### DIFF
--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -22,3 +22,21 @@
 if ( ! defined( 'WP_POST_REVISIONS' ) ) {
 	define( 'WP_POST_REVISIONS', 500 );
 }
+
+/**
+ * Disable New Relic Browser instrumentation.
+ *
+ * By default, the New Relic extension automatically enables Browser instrumentation.
+ *
+ * This injects some New Relic specific javascript onto all pages on the VIP Platform.
+ *
+ * This isn't always desireable (e.g. impacts performance) so let's turn it off.
+ *
+ * If you would like to enable Browser intrumentation, please remove the lines below.
+ *
+ * @see https://docs.newrelic.com/docs/agents/php-agent/features/new-relic-browser-php-agent#disable
+ * @see https://wpvip.com/documentation/vip-go/new-relic-on-vip-go/
+ */
+if ( function_exists( 'newrelic_disable_autorum' ) ) {
+	newrelic_disable_autorum();
+}


### PR DESCRIPTION
It's not ideal to have it automatically enabled since most sites don't use it and it just shows up as extra javascript on the site.

This will disable for all new applications but allows customers to re-enable by removing the disable lines.

See https://wp.me/p6jPRI-3l7