### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# This file is for unifying the coding style for different editors and IDEs
+# It is based on https://core.trac.wordpress.org/browser/trunk/.editorconfig
+# See https://editorconfig.org for more information about the standard.
+# WordPress VIP documentation: https://docs.wpvip.com/technical-references/vip-codebase/editorconfig/
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.txt]
+end_of_line = crlf


### PR DESCRIPTION
EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. See https://editorconfig.org/ for more information.

Here we use a very slightly amended version of the WordPress core [`.editorconfig`](https://core.trac.wordpress.org/browser/trunk/.editorconfig) file; the only differences are some comment clarifications and the removal of the `wp-config-sample.php` reference, which is a file found in WordPress core, but not in customer repositories that are generated from the vip-go-skeleton.

Originally proposed as part of #29, but now moved to its own PR.

Proposed [docs page](https://docs.wpvip.com/technical-references/vip-codebase/) update to do if/once this PR is merged: 

> It also contains an `.editorconfig` file which is used for unifying the coding style for different editors and IDEs, that matches the [editor configuration used by WordPress core](https://core.trac.wordpress.org/browser/trunk/.editorconfig).