### PR TITLE
Add `node_modules` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-# Development files
+# Dependencies
+## Avoid any node_modules folders anywhere in the repo; see see https://docs.wpvip.com/how-tos/manage-dependencies/#version-management
 node_modules
-package.json
-package-lock.json
+## Avoid package*.json files only at repo root
+/package.json
+/package-lock.json
 
 # Built-in; ship with vip-go-mu-plugins
 /plugins/akismet/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Development files
+node_modules
 package.json
 package-lock.json
 


### PR DESCRIPTION
Node.js-driven development within WordPress plugins and themes means that developers often end up with huge `node_modules` folders in their projects. These are used to generate a deployment artifact and almost never need to be committed. 

Accidentally committing `node_modules` can result in a truly epic number of tracked files and can slow down many operations, both locally and on VIP infrastructure.