### PR TITLE
bumped the minimum_supported_wp_version to 6.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -47,7 +47,7 @@
 	<!--<rule ref="WordPress-Docs"/>-->
 	<!-- For help in understanding this minimum_supported_wp_version:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-for-all-sniffs-in-one-go-wpcs-0140 -->
-	<config name="minimum_supported_wp_version" value="5.9-"/>
+	<config name="minimum_supported_wp_version" value="6.0-"/>
 
 	<!-- For more information on customizing this file, see https://docs.wpvip.com/technical-references/vip-codebase/phpcs-xml-dist/. -->
 </ruleset>


### PR DESCRIPTION
This is in keeping with the new default version of WordPress on WPVIP: WordPress 6.0.