### PR TITLE
Add defensive check before defining WP_DEBUG

### DIFF
--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -67,6 +67,7 @@ if ( function_exists( 'newrelic_disable_autorum' ) ) {
  *
  * @see https://wordpress.org/support/article/debugging-in-wordpress/#wp_debug
  */
-if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) ) {
+if ( ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' !== VIP_GO_APP_ENVIRONMENT ) )
+	&& ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', true );
 }


### PR DESCRIPTION
We should check that `WP_DEBUG` hasn't been defined anywhere else before defining it:

```
Warning: Constant WP_DEBUG already defined in /wp/wp-content/vip-config/vip-config.php on line 71 [$ /usr/local/bin/wp --allow-root vip-search health validate-counts] [wp-content/vip-config/vip-config.php:71 define(), config/wp-config-defaults.php:79 require_once('wp-content/vip-config/vip-config.php'), config/wp-config.php:32 require('config/wp-config-defaults.php'), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1277) : eval()'d code:1 require('config/wp-config.php'), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1277 eval(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1235 WP_CLI\Runner-&gt;load_wordpress(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28 WP_CLI\Runner-&gt;start(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/bootstrap.php:78 WP_CLI\Bootstrap\LaunchRunner-&gt;process(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php:27 WP_CLI\bootstrap(), phar:///usr/local/binphp/boot-phar.php:11 include('phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/binphp/boot-phar.php')]
```