### PR TITLE
Update Twenty Twenty Two to v1.3

### DIFF
--- a/themes/twentytwentytwo/inc/patterns/footer-dark.php
+++ b/themes/twentytwentytwo/inc/patterns/footer-dark.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Dark footer wtih title and citation
+ * Dark footer with title and citation
  */
 return array(
 	'title'      => __( 'Dark footer with title and citation', 'twentytwentytwo' ),

--- a/themes/twentytwentytwo/readme.txt
+++ b/themes/twentytwentytwo/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Two ===
 Contributors: wordpressdotorg
 Requires at least: 5.9
-Tested up to: 6.0
+Tested up to: 6.1
 Requires PHP: 5.6
-Stable tag: 1.2
+Stable tag: 1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,6 +16,11 @@ The true richness of Twenty Twenty-Two lies in its opportunity for customization
 Whether you’re building a single-page website, a blog, a business website, or a portfolio, Twenty Twenty-Two will help you create a site that is uniquely yours.
 
 == Changelog ==
+
+= 1.3 =
+* Released: November 1, 2022
+
+https://wordpress.org/support/article/twenty-twenty-two-changelog#Version_1.3
 
 = 1.2 =
 * Released: May 24, 2022

--- a/themes/twentytwentytwo/style.css
+++ b/themes/twentytwentytwo/style.css
@@ -5,13 +5,13 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Built on a solidly designed foundation, Twenty Twenty-Two embraces the idea that everyone deserves a truly unique website. The theme’s subtle styles are inspired by the diversity and versatility of birds: its typography is lightweight yet strong, its color palette is drawn from nature, and its layout elements sit gently on the page. The true richness of Twenty Twenty-Two lies in its opportunity for customization. The theme is built to take advantage of the Full Site Editing features introduced in WordPress 5.9, which means that colors, typography, and the layout of every single page on your site can be customized to suit your vision. It also includes dozens of block patterns, opening the door to a wide range of professionally designed layouts in just a few clicks. Whether you’re building a single-page website, a blog, a business website, or a portfolio, Twenty Twenty-Two will help you create a site that is uniquely yours.
 Requires at least: 5.9
-Tested up to: 6.0
+Tested up to: 6.1
 Requires PHP: 5.6
-Version: 1.2
+Version: 1.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, accessibility-ready
 
 Twenty Twenty-Two WordPress Theme, (C) 2021 WordPress.org
 Twenty Twenty-Two is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
Updates default theme Twenty Twenty Two to v1.3, released on 1 Nov 2022, coinciding with WordPress 6.1.

Last updated to v1.2 in https://github.com/Automattic/vip-go-skeleton/pull/82.