### PR TITLE
.gitignore: Remove remnants of debug-bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ package-lock.json
 /plugins/akismet/
 /plugins/advanced-post-cache/
 /plugins/cron-control/
-/plugins/debug-bar/
-/plugins/debug-bar-cron/
 /plugins/gutenberg-ramp/
 /plugins/jetpack/
 /plugins/jetpack-force-2fa/


### PR DESCRIPTION
https://lobby.vip.wordpress.com/2022/12/14/deprecation-notice-debug-bar-january-31-2023/