### PR TITLE
Bump down WP_POST_REVISIONS to 100, add a link to the technical reference on docs.wpvip.com site

### DIFF
--- a/vip-config/vip-config.php
+++ b/vip-config/vip-config.php
@@ -21,12 +21,14 @@
 /**
  * Set a high default limit to avoid too many revisions from polluting the database.
  *
- * Posts with extremely high revisions can result in fatal errors or have performance issues.
+ * @see https://docs.wpvip.com/technical-references/vip-platform/post-revisions/
+ *
+ * Posts with high revisions can result in fatal errors or have performance issues.
  *
  * Feel free to adjust this depending on your use cases.
  */
 if ( ! defined( 'WP_POST_REVISIONS' ) ) {
-	define( 'WP_POST_REVISIONS', 500 );
+	define( 'WP_POST_REVISIONS', 100 );
 }
 
 /**


### PR DESCRIPTION
High revision counts keep on being a problem, so we decrease the value to 100 for new sites.