### PR TITLE
Update Twenty Twenty Three to v1.2

### DIFF
--- a/themes/twentytwentythree/patterns/call-to-action.php
+++ b/themes/twentytwentythree/patterns/call-to-action.php
@@ -32,8 +32,8 @@
 
 	<!-- wp:column -->
 	<div class="wp-block-column">
-		<!-- wp:separator -->
-		<hr class="wp-block-separator has-alpha-channel-opacity"/>
+		<!-- wp:separator {"className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
 		<!-- /wp:separator -->
 	</div>
 	<!-- /wp:column -->

--- a/themes/twentytwentythree/readme.txt
+++ b/themes/twentytwentythree/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Three ===
 Contributors: wordpressdotorg
 Requires at least: 6.1
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 5.6
-Stable tag: 1.1
+Stable tag: 1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,6 +14,11 @@ Twenty Twenty-Three is designed to take advantage of the new design tools introd
 Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
 
 == Changelog ==
+
+= 1.2 =
+* Released: August 8, 2023
+
+https://wordpress.org/documentation/article/twenty-twenty-three-changelog/#Version_1.2
 
 = 1.1 =
 * Released: March 28, 2023

--- a/themes/twentytwentythree/style.css
+++ b/themes/twentytwentythree/style.css
@@ -5,11 +5,11 @@ Author: the WordPress team
 Author URI: https://wordpress.org
 Description: Twenty Twenty-Three is designed to take advantage of the new design tools introduced in WordPress 6.1. With a clean, blank base as a starting point, this default theme includes ten diverse style variations created by members of the WordPress community. Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
 Requires at least: 6.1
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 5.6
-Version: 1.1
+Version: 1.2
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: twentytwentythree
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, block-styles, accessibility-ready, blog, portfolio, news
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, block-styles, style-variations, accessibility-ready, blog, portfolio, news
 */

--- a/themes/twentytwentythree/styles/marigold.json
+++ b/themes/twentytwentythree/styles/marigold.json
@@ -153,7 +153,6 @@
 				"elements": {
 					"link": {
 						"typography": {
-							"fontSize": "var(--wp--preset--font-size--large)",
 							"textDecoration": "none"
 						},
 						"color": {
@@ -168,6 +167,7 @@
 					}
 				},
 				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "600"
 				}
 			},
@@ -203,14 +203,8 @@
 				}
 			},
 			"core/site-title": {
-				"elements": {
-					"link": {
-						"typography": {
-							"fontSize": "var(--wp--preset--font-size--normal)"
-						}
-					}
-				},
 				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"textTransform": "lowercase"
 				}
 			}

--- a/themes/twentytwentythree/styles/whisper.json
+++ b/themes/twentytwentythree/styles/whisper.json
@@ -288,16 +288,15 @@
 							}
 						},
 						"typography": {
-							"fontFamily": "var(--wp--preset--font-family--dm-sans)",
-							"fontSize": "var(--wp--preset--font-size--large)",
-							"fontWeight": "700",
-							"letterSpacing": "-0.01em",
 							"textDecoration": "none"
 						}
 					}
 				},
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--dm-sans)",
 					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "700",
+					"letterSpacing": "-0.01em",
 					"lineHeight": "1.4",
 					"textTransform": "capitalize"
 				}

--- a/themes/twentytwentythree/templates/archive.html
+++ b/themes/twentytwentythree/templates/archive.html
@@ -4,10 +4,10 @@
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
 	<!-- wp:query-title {"type":"archive","align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
 
-	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
+	<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
-			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
+			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"clamp(15vw, 30vh, 400px)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"isLink":true} /-->

--- a/themes/twentytwentythree/templates/home.html
+++ b/themes/twentytwentythree/templates/home.html
@@ -6,10 +6,10 @@
 	<h1 class="alignwide" style="margin-bottom:var(--wp--preset--spacing--60)">Mindblown: a blog about philosophy.</h1>
 	<!-- /wp:heading -->
 
-	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
+	<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"constrained"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
-			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
+			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"clamp(15vw, 30vh, 400px)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"isLink":true} /-->

--- a/themes/twentytwentythree/templates/index.html
+++ b/themes/twentytwentythree/templates/index.html
@@ -2,10 +2,10 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
+	<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
-			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
+			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"clamp(15vw, 30vh, 400px)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true,"align":"wide"} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"isLink":true} /-->

--- a/themes/twentytwentythree/templates/search.html
+++ b/themes/twentytwentythree/templates/search.html
@@ -4,10 +4,10 @@
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70);margin-bottom:var(--wp--preset--spacing--70)">
 	<!-- wp:query-title {"type":"search","align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
 
-	<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
+	<!-- wp:query {"query":{"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"align":"wide"} -->
-			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"max(15vw, 30vh)","align":"wide"} /-->
+			<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"clamp(15vw, 30vh, 400px)","align":"wide"} /-->
 			<!-- wp:post-title {"isLink":true} /-->
 			<!-- wp:post-excerpt /-->
 			<!-- wp:post-date {"isLink":true} /-->

--- a/themes/twentytwentythree/theme.json
+++ b/themes/twentytwentythree/theme.json
@@ -539,7 +539,11 @@
 			},
 			"core/quote": {
 				"border": {
-					"width": "1px"
+					"left": {
+						"color": "inherit",
+						"style": "solid",
+						"width": "1px"
+					}
 				},
 				"elements": {
 					"cite": {
@@ -587,6 +591,9 @@
 					"fontWeight": "normal",
 					"lineHeight": "1.4"
 				}
+			},
+			"core/separator": {
+				"css": " &:not(.is-style-wide):not(.is-style-dots):not(.alignwide):not(.alignfull){width: 100px}"
 			}
 		},
 		"color": {


### PR DESCRIPTION
Updates the [Twenty Twenty Three](https://wordpress.org/themes/twentytwentythree/) theme, last updated in #98, from v1.1 to v1.2, released 8 Aug 2023.