### PR TITLE
Set PHPCS severity level to match vipgoci-bot

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -31,6 +31,18 @@
 	<arg name="parallel" value="8"/> <!-- Enables parallel processing when available for faster results -->
 	<arg name="extensions" value="php,js"/> <!-- Limit to PHP and JS files -->
 
+	<!--
+	Set default PHPCS severity level to 1 to match VIP Code Analysis Bot defaults.
+	Default PHPCS severity is 5 for errors/warnings.
+
+	PHPCS severity config:
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#changing-the-default-severity-levels
+
+	VIP Code Analysis Bot customization:
+	https://docs.wpvip.com/vip-code-analysis-bot/customize-the-bot/#h-phpcs-severity
+	-->
+	<arg name="severity" value="1"/>
+
 	<!-- Rules: Check PHP version compatibility - see
 		https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -6,12 +6,12 @@
 	<description>Custom ruleset for VIP sites.</description>
 
 	<!-- Note: this file is only used for local PHPCS checks; the vip-go-ci bot does not read it.
-	To customize the bot's behavior, see https://docs.wpvip.com/how-tos/customize-the-bot/. -->
+	To customize the bot's behavior, see https://docs.wpvip.com/vip-code-analysis-bot/customize-the-bot/. -->
 
 	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
 	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
-	<!-- For VIP code review items: https://docs.wpvip.com/technical-references/code-review/ -->
-	<!-- For VIP PHPCS severity levels: https://docs.wpvip.com/technical-references/vip-code-analysis-bot/phpcs-report/ -->
+	<!-- For VIP code review items: https://docs.wpvip.com/development-workflow/code-review/ -->
+	<!-- For VIP PHPCS severity levels: https://docs.wpvip.com/php_codesniffer/phpcs-report/ -->
 
 	<!-- What to scan -->
 	<file>./themes/</file>
@@ -62,5 +62,5 @@
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-for-all-sniffs-in-one-go-wpcs-0140 -->
 	<config name="minimum_supported_wp_version" value="6.1"/>
 
-	<!-- For more information on customizing this file, see https://docs.wpvip.com/technical-references/vip-codebase/phpcs-xml-dist/. -->
+	<!-- For more information on customizing this file, see https://docs.wpvip.com/wordpress-skeleton/phpcs-xml-dist/. -->
 </ruleset>


### PR DESCRIPTION
The VIP Code Analysis Bot sets the PHPCS severity level to `1` during pull request scans, while the default severity level of the PHPCS tooling itself is `5`. Aligning these settings will avoid surprises once a pull request is opened and the bot reveals issues that weren't flagged during local development scanning.

https://docs.wpvip.com/vip-code-analysis-bot/customize-the-bot/#h-phpcs-severity
https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#changing-the-default-severity-levels

Documentation links for "docs.wpvip.com" were also updated to point to more accurate pages.