### PR TITLE
Update Twenty Twenty Two to v2.0

### DIFF
--- a/themes/twentytwentytwo/functions.php
+++ b/themes/twentytwentytwo/functions.php
@@ -9,7 +9,6 @@
  * @since Twenty Twenty-Two 1.0
  */
 
-
 if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 
 	/**
@@ -61,5 +60,5 @@ endif;
 
 add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
 
-// Add block patterns
+// Add block patterns.
 require get_template_directory() . '/inc/block-patterns.php';

--- a/themes/twentytwentytwo/readme.txt
+++ b/themes/twentytwentytwo/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Two ===
 Contributors: wordpressdotorg
 Requires at least: 5.9
-Tested up to: 6.7
+Tested up to: 6.8
 Requires PHP: 5.6
-Stable tag: 1.9
+Stable tag: 2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +38,11 @@ Follow these instructions for each of the following templates:
 - Single Post (No Separators)
 
 == Changelog ==
+
+= 2.0 =
+* Released: April 15, 2025
+
+https://wordpress.org/documentation/article/twenty-twenty-two-changelog/#Version_2.0
 
 = 1.9 =
 * Released: November 12, 2024
@@ -91,7 +96,7 @@ https://wordpress.org/documentation/article/twenty-twenty-two-changelog/#Version
 
 == Copyright ==
 
-Twenty Twenty-Two WordPress Theme, 2021-2024 WordPress.org and contributors.
+Twenty Twenty-Two WordPress Theme, 2021-2025 WordPress.org and contributors.
 Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Updates Twenty Twenty Two theme, last updated in #116, to v2.0, released 15 Apr 2025.