### PR TITLE
Added `.deployignore` file

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,33 +1,37 @@
 # Files and directories to exclude from deployment
 
+# Development and other files not needed in production
+.editorconfig
+.gitignore
+composer.json
+composer.lock
+readme.txt
+README.md
+LICENSE
+license.txt
+webpack.config.js
+
 # PHP CodeSniffer configs
+.phpcs.xml
 phpcs.xml
+.phpcs.xml.dist
 phpcs.xml.dist
 
 # PHPUnit test configs
 phpunit.xml
 phpunit.xml.dist
 
-# Editor config
-.editorconfig
-
 # Environment file (contains secrets)
 .env
 
-# Git repository
+# Development directories
+.cursor/
+.devcontainer/
 .git/
-
-# GitHub workflows
 .github/
-
-# VS Code settings
 .vscode/
-
-# Node dependencies
+.wpvip/
 node_modules/
-
-# Test files
 tests/
-
-# Documentation
 docs/
+/config/

--- a/.deployignore
+++ b/.deployignore
@@ -1,0 +1,33 @@
+# Files and directories to exclude from deployment
+
+# PHP CodeSniffer configs
+phpcs.xml
+phpcs.xml.dist
+
+# PHPUnit test configs
+phpunit.xml
+phpunit.xml.dist
+
+# Editor config
+.editorconfig
+
+# Environment file (contains secrets)
+.env
+
+# Git repository
+.git/
+
+# GitHub workflows
+.github/
+
+# VS Code settings
+.vscode/
+
+# Node dependencies
+node_modules/
+
+# Test files
+tests/
+
+# Documentation
+docs/


### PR DESCRIPTION
## Add deployment ignore file

Added `.deployignore` to exclude development files from production deployments.

**What's excluded:**
- Config files (phpcs, phpunit, .editorconfig) 
- Sensitive files (.env)
- Dev tools (.git, .github, .vscode, node_modules)
- Tests and docs

**Benefits:**
- Improves security (no sensitive files in production)
- Reduces deployment size
- Cleaner production environment


closes #44 