### PR TITLE
Update minimum PHP and WP version for new applications

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -60,7 +60,7 @@
 	<!--<rule ref="WordPress-Docs"/>-->
 	<!-- For help in understanding this minimum_supported_wp_version:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-for-all-sniffs-in-one-go-wpcs-0140 -->
-	<config name="minimum_supported_wp_version" value="6.1"/>
+	<config name="minimum_supported_wp_version" value="6.8"/>
 
 	<!-- For more information on customizing this file, see https://docs.wpvip.com/wordpress-skeleton/phpcs-xml-dist/. -->
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -48,7 +48,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="8.1-"/>
+	<config name="testVersion" value="8.2-"/>
 
 	<!-- Rules: VIP Coding Standards - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "homepage": "https://github.com/automattic/vip-go-skeleton",
   "license": "GPL-2.0-or-later",
   "require": {
-    "php": ">=8.0"
+    "php": ">=8.2"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3",


### PR DESCRIPTION
VIP will require PHP 8.2 as the minimum version later on in 2025, so let's make this a requirement for new applications being created from this skeleton repository.

Likewise, new applications have no need to be created using any version other than the latest version of WordPress, so we can increase that in the PHPCS config as well.