### PR TITLE
chore: update devcontainer config to use `ubuntu-base` image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "WordPress VIP Codespace",
-    "image": "ghcr.io/automattic/vip-codespaces/alpine-base:latest",
+    "image": "ghcr.io/automattic/vip-codespaces/ubuntu-base:latest",
     "overrideCommand": false,
     "forwardPorts": [80, 81, 8025],
     "portsAttributes": {
@@ -46,8 +46,8 @@
             "mediaRedirectURL": ""
         },
         "ghcr.io/automattic/vip-codespaces/php:latest": {
-            // PHP version options: 8.1, 8.2, 8.3
-            "version": "8.2",
+            // PHP version options: 8.1, 8.2, 8.3, 8.4
+            "version": "8.3",
             "composer": true
         },
         "ghcr.io/automattic/vip-codespaces/mariadb:latest": {


### PR DESCRIPTION
This pull request updates the development container configuration in `.devcontainer/devcontainer.json` to improve compatibility and modernize the setup. The most important changes include switching the base image to Ubuntu and upgrading the default PHP version.

### Updates to the development container configuration:

* Changed the base image from `ghcr.io/automattic/vip-codespaces/alpine-base:latest` to `ghcr.io/automattic/vip-codespaces/ubuntu-base:latest` for better compatibility and support.
* Updated the default PHP version from `8.2` to `8.3`, with the addition of support for PHP `8.4` as an option in the comments.

The goal of this pull request is to transition from Alpine to Ubuntu and deprecate the Alpine base image, as it requires excessive maintenance.
