### PR TITLE
Update Twenty Twenty Five to v1.3

### DIFF
--- a/themes/twentytwentyfive/functions.php
+++ b/themes/twentytwentyfive/functions.php
@@ -34,7 +34,7 @@ if ( ! function_exists( 'twentytwentyfive_editor_style' ) ) :
 	 * @return void
 	 */
 	function twentytwentyfive_editor_style() {
-		add_editor_style( get_parent_theme_file_uri( 'assets/css/editor-style.css' ) );
+		add_editor_style( 'assets/css/editor-style.css' );
 	}
 endif;
 add_action( 'after_setup_theme', 'twentytwentyfive_editor_style' );

--- a/themes/twentytwentyfive/readme.txt
+++ b/themes/twentytwentyfive/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Requires at least: 6.7
 Tested up to: 6.8
 Requires PHP: 7.2
-Stable tag: 1.2
+Stable tag: 1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,6 +13,11 @@ Twenty Twenty-Five emphasizes simplicity and adaptability. It offers flexible de
 
 
 == Changelog ==
+
+= 1.3 =
+* Released: July 15, 2025
+
+https://wordpress.org/documentation/article/twenty-twenty-five-changelog/#Version_1.3
 
 = 1.2 =
 * Released: April 15, 2025


### PR DESCRIPTION
Updates Twenty Twenty Five theme, last updated in #122, to v1.3, released 5 Aug 2025.